### PR TITLE
Fix memcached max item size 1M

### DIFF
--- a/chart_server/src/main/kotlin/io/madrona/njord/db/TileDao.kt
+++ b/chart_server/src/main/kotlin/io/madrona/njord/db/TileDao.kt
@@ -9,6 +9,7 @@ import io.madrona.njord.model.ChartFeatureInfo
 import io.madrona.njord.util.logger
 import net.rubyeye.xmemcached.XMemcachedClientBuilder
 import net.rubyeye.xmemcached.command.BinaryCommandFactory
+import net.rubyeye.xmemcached.transcoders.SerializingTranscoder
 import java.net.InetSocketAddress
 
 class TileDao(
@@ -25,6 +26,7 @@ class TileDao(
             it.isEnableHealSession = true
             it.healSessionInterval = 2000
             it.commandFactory = BinaryCommandFactory()
+            it.transcoder = SerializingTranscoder(10*1024*1024)   // memcached -I 10M -m 1024
         }.build()
 
     fun clearCache() {

--- a/chart_server_db/docker-compose.yaml
+++ b/chart_server_db/docker-compose.yaml
@@ -20,6 +20,8 @@ services:
       - overlay
     ports:
       - "11211:11211"
+    command: memcached -I 128m -m 512
+  #docker run --name memcached -d -p 11211:11211 memcached memcached -m 512 -I 128m
 
   postgres:
     image: 'postgis/postgis:13-3.1'
@@ -38,25 +40,25 @@ services:
       POSTGRES_PASSWORD: mysecretpassword
       POSTGRES_DB: s57server
 
-  postgressetup:
-    build:
-      context: ./postgres_init
-      dockerfile: Dockerfile
-    depends_on:
-      - postgres
-    networks:
-      - overlay
-    restart: "no"
-    volumes:
-      - ./postgres_init/scripts:/postgres_init
-    environment:
-      PGUSER: admin
-      PGPASSWORD: mysecretpassword
-      PGHOST: postgres
-      PGPORT: 5432
-      PGDATABASE: s57server
+  # postgressetup:
+  #   build:
+  #     context: ./postgres_init
+  #     dockerfile: Dockerfile
+  #   depends_on:
+  #     - postgres
+  #   networks:
+  #     - overlay
+  #   restart: "no"
+  #   volumes:
+  #     - ./postgres_init/scripts:/postgres_init
+  #   environment:
+  #     PGUSER: admin
+  #     PGPASSWORD: mysecretpassword
+  #     PGHOST: postgres
+  #     PGPORT: 5432
+  #     PGDATABASE: s57server
 
-    entrypoint: [ "/postgres_init/postgres_init.sh" ]
+  #   entrypoint: [ "/postgres_init/postgres_init.sh" ]
 
 
 networks:

--- a/chart_server_db/docker-compose.yaml
+++ b/chart_server_db/docker-compose.yaml
@@ -40,25 +40,25 @@ services:
       POSTGRES_PASSWORD: mysecretpassword
       POSTGRES_DB: s57server
 
-  # postgressetup:
-  #   build:
-  #     context: ./postgres_init
-  #     dockerfile: Dockerfile
-  #   depends_on:
-  #     - postgres
-  #   networks:
-  #     - overlay
-  #   restart: "no"
-  #   volumes:
-  #     - ./postgres_init/scripts:/postgres_init
-  #   environment:
-  #     PGUSER: admin
-  #     PGPASSWORD: mysecretpassword
-  #     PGHOST: postgres
-  #     PGPORT: 5432
-  #     PGDATABASE: s57server
+  postgressetup:
+    build:
+      context: ./postgres_init
+      dockerfile: Dockerfile
+    depends_on:
+      - postgres
+    networks:
+      - overlay
+    restart: "no"
+    volumes:
+      - ./postgres_init/scripts:/postgres_init
+    environment:
+      PGUSER: admin
+      PGPASSWORD: mysecretpassword
+      PGHOST: postgres
+      PGPORT: 5432
+      PGDATABASE: s57server
 
-  #   entrypoint: [ "/postgres_init/postgres_init.sh" ]
+    entrypoint: [ "/postgres_init/postgres_init.sh" ]
 
 
 networks:


### PR DESCRIPTION
When you have a dense map with zoom level like 6, there is an error like "item over size 1M" from memcached. To fix it, you need give memcached server an parameter -I 10M and change transcoder in TileDao.kt.