### PR TITLE
Fix handling of multiple M_COVR coverage areas

### DIFF
--- a/chart_server/src/main/kotlin/io/madrona/njord/geo/TileEncoder.kt
+++ b/chart_server/src/main/kotlin/io/madrona/njord/geo/TileEncoder.kt
@@ -4,7 +4,7 @@ import com.codahale.metrics.Timer
 import io.madrona.njord.Singletons
 import io.madrona.njord.db.ChartDao
 import io.madrona.njord.geo.symbols.S57ObjectLibrary
-import no.ecc.vectortile.VectorTileEncoder;
+import no.ecc.vectortile.VectorTileEncoder
 import io.madrona.njord.layers.LayerFactory
 import io.madrona.njord.model.ChartFeatureInfo
 import org.locationtech.jts.geom.Geometry
@@ -103,8 +103,9 @@ class TileEncoder(
     }
 
     private fun addPly(chartGeo: Geometry) {
-        (chartGeo as? Polygon)?.let { ply ->
-            val plyTile = tileSystem.tileGeometry(ply.exteriorRing, x, y, z)
+        (0 until chartGeo.numGeometries).forEach { i ->
+            val polygon = chartGeo.getGeometryN(i) as Polygon
+            val plyTile = tileSystem.tileGeometry(polygon.exteriorRing, x, y, z)
             encoder.addFeature("PLY", emptyMap<String, Any?>(), plyTile)
         }
     }


### PR DESCRIPTION
This PR addresses issue #54 by:
- Adding support for MultiPolygon geometry in M_COVR features
- Modifying TileEncoder to handle both Polygon and MultiPolygon cases for the "PLY" layer.

Testing:
- Tested with charts containing single and multiple M_COVR areas (eg.US5CA46M, US5CA63M, US5MI67M, US5MI42M, US6WI01M which contain 2 or 3 distinct coverage areas.)
- Verified correct display of coverage areas in all cases
- Existing functionality remains unchanged

