### PR TITLE
Remove upload size limit

### DIFF
--- a/chart_server/build.gradle.kts
+++ b/chart_server/build.gradle.kts
@@ -40,8 +40,8 @@ kotlin {
             kotlin.srcDir("build/generated/source/version")
             dependencies {
                 implementation(project(":shared"))
-                implementation("io.ktor:ktor-server-core-jvm")
-                implementation("io.ktor:ktor-server-netty-jvm")
+                implementation("io.ktor:ktor-server-core-jvm:$ktorVersion")
+                implementation("io.ktor:ktor-server-netty-jvm:$ktorVersion")
                 implementation("ch.qos.logback:logback-classic:$logbackVersion")
                 implementation("io.ktor:ktor-server-status-pages:${ktorVersion}")
                 implementation("io.ktor:ktor-server-content-negotiation:$ktorVersion")

--- a/chart_server/src/jvmMain/kotlin/io/madrona/njord/endpoints/EncSaveHandler.kt
+++ b/chart_server/src/jvmMain/kotlin/io/madrona/njord/endpoints/EncSaveHandler.kt
@@ -41,7 +41,7 @@ class EncSaveHandler(
     }
 
     override suspend fun handlePost(call: ApplicationCall) = call.requireSignature {
-        val multipartData = call.receiveMultipart()
+        val multipartData = call.receiveMultipart(formFieldLimit = Long.MAX_VALUE)
         val uuid = UUID.randomUUID().toString()
         val tempDir = File(charDir, uuid)
         val files = mutableListOf<String>()


### PR DESCRIPTION
Since Ktor 3.0.0, a default limit of 50 MB on receiving multipart/form-data binary items has been applied. Setting formFieldLimit to Long.MAX_VALUE to remove this restriction.