### PR TITLE
Fix ol-mapbox-style rendering

### DIFF
--- a/chart_server/src/jvmMain/kotlin/io/madrona/njord/endpoints/StyleHandler.kt
+++ b/chart_server/src/jvmMain/kotlin/io/madrona/njord/endpoints/StyleHandler.kt
@@ -9,7 +9,7 @@ import io.madrona.njord.ext.KtorHandler
 import io.madrona.njord.ext.fromString
 import io.madrona.njord.layers.*
 import io.madrona.njord.model.*
-import kotlinx.serialization.json.Json.Default.encodeToString
+import kotlinx.serialization.json.Json
 
 
 class StyleHandler(
@@ -18,6 +18,10 @@ class StyleHandler(
     private val colorLibrary: ColorLibrary = Singletons.colorLibrary,
 ) : KtorHandler {
     override val route = "/v1/style/{depth}/{theme}"
+    private val styleJson = Json {
+        encodeDefaults = true
+        explicitNulls = false
+    }
 
     override suspend fun handleGet(call: ApplicationCall) {
         fromString<Depth>(call.parameters["depth"])?.let { depth ->
@@ -34,7 +38,7 @@ class StyleHandler(
     }
 
     private fun styleString(name: String, depth: Depth, theme: Theme): String {
-        return encodeToString(
+        return styleJson.encodeToString(
             Style.serializer(),
             Style(
                 name = name,

--- a/chart_server/src/jvmMain/kotlin/io/madrona/njord/layers/Background.kt
+++ b/chart_server/src/jvmMain/kotlin/io/madrona/njord/layers/Background.kt
@@ -14,8 +14,8 @@ class Background : Layerable() {
                 backgroundColor = colorFrom(Color.NODTA, options.theme),
                 backgroundOpacity = 1
             ),
-            type = LayerType.BACKGROUND,
             source = null,
+            type = LayerType.BACKGROUND,
         )
     )
 }


### PR DESCRIPTION
The way the rendering algorithm in ol-mapbox-style works is that it groups layers by source, and sets up the source on the first layer with that source. When this layer is a background, it does not set up a vector source for the other layers, and they do not render. I have mentioned this error in ol-mapbox-style, however looking at the mapbox spec it seems that having a background layer with a source is not valid anyway. Either way, setting the source to null seems to fix the issue.