### PR TITLE
Update base image from buster to bookworm

### DIFF
--- a/chart_server_db/postgres_init/Dockerfile
+++ b/chart_server_db/postgres_init/Dockerfile
@@ -1,5 +1,5 @@
 # Image for initializing the PostGIS Db
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y postgresql-client
 


### PR DESCRIPTION
Debian Buster (10) reached End of Life in June 2024. Its APT repositories have since been removed from official mirrors, causing apt-get update to fail with 404 errors during the Docker build. This updates the base image to debian:bookworm-slim (Debian 12), which is actively maintained and LTS until 2028.