### PR TITLE
Fix TSEZNE transparency per S-52 AC(TRFCF,3)

### DIFF
--- a/server/src/nativeMain/kotlin/io/madrona/njord/layers/Layerable.kt
+++ b/server/src/nativeMain/kotlin/io/madrona/njord/layers/Layerable.kt
@@ -246,6 +246,23 @@ abstract class Layerable(
         )
     }
 
+    fun areaLayerWithFillColor(
+        color: Color,
+        theme: Theme,
+        opacity: Float
+    ): Layer {
+        return Layer(
+            id = "${key}_fill_${++nextId}",
+            type = LayerType.FILL,
+            sourceLayer = sourceLayer,
+            filter = Filters.eqTypePolyGon,
+            paint = Paint(
+                fillColor = colorFrom(color, theme).json,
+                fillOpacity = opacity
+            ),
+        )
+    }
+
     fun areaLayerWithFillPattern(symbol: Sprite? = null): Layer {
         return Layer(
             id = "${key}_fill_pattern_${++nextId}",

--- a/server/src/nativeMain/kotlin/io/madrona/njord/layers/Tsezne.kt
+++ b/server/src/nativeMain/kotlin/io/madrona/njord/layers/Tsezne.kt
@@ -18,6 +18,6 @@ class Tsezne : Layerable() {
     }
 
     override fun layers(options: LayerableOptions) = sequenceOf(
-        areaLayerWithFillColor(ac, options.theme),
+        areaLayerWithFillColor(ac, options.theme, opacity = 0.25f),
     )
 }

--- a/shared/src/commonMain/kotlin/io/madrona/njord/model/Style.kt
+++ b/shared/src/commonMain/kotlin/io/madrona/njord/model/Style.kt
@@ -39,6 +39,7 @@ data class Paint(
     @SerialName("background-color") val backgroundColor: String? = null,
     @SerialName("background-opacity") val backgroundOpacity: Int? = null,
     @SerialName("fill-color") val fillColor: JsonElement? = null,
+    @SerialName("fill-opacity") val fillOpacity: Float? = null,
     @SerialName("fill-pattern") val fillPattern: JsonElement? = null, //List<String> or String>
     @SerialName("line-color") val lineColor: JsonElement? = null,
     @SerialName("line-width") val lineWidth: Float? = null,


### PR DESCRIPTION
## Summary

- Add `fill-opacity` support to the `Paint` data class (`fillOpacity: Float?`)
- Add opacity-aware `areaLayerWithFillColor(color, theme, opacity)` overload in `Layerable`
- Apply `opacity = 0.25f` to TSEZNE, matching S-52 lookup table `AC(TRFCF,3)` — the TRNSP token specifies 75% background visibility

Fixes #106

## Context

The S-52 Presentation Library defines TSEZNE rendering as `AC(TRFCF,3)`, where the transparency parameter references the TRNSP color token (S-52 Table 3): *"used in transparent area fills (e.g. traffic separation zones), to let the background colour show through, say, 75% of the pixels."*

Unlike the DRGARE fix (#103) which uses a pattern fill `AP(DRGARE01)` as specified in S-52, TSEZNE uses a color with transparency — so `fill-opacity` is the appropriate MapLibre equivalent.

## Files changed

- `shared/src/commonMain/kotlin/io/madrona/njord/model/Style.kt`
- `server/src/nativeMain/kotlin/io/madrona/njord/layers/Layerable.kt`
- `server/src/nativeMain/kotlin/io/madrona/njord/layers/Tsezne.kt`