### PR TITLE
Set promoteId

### DIFF
--- a/server/src/nativeMain/kotlin/io/madrona/njord/endpoints/StyleHandler.kt
+++ b/server/src/nativeMain/kotlin/io/madrona/njord/endpoints/StyleHandler.kt
@@ -46,7 +46,8 @@ class StyleHandler(
                 sources = mapOf(
                     Source.SENC to Source(
                         type = SourceType.VECTOR,
-                        tileJsonUrl = "$baseUrl/v1/tile_json"
+                        tileJsonUrl = "$baseUrl/v1/tile_json",
+                        promoteId = "LNAM"
                     )
                 ),
                 layers = layerFactory.layers(LayerableOptions(depth, theme)),

--- a/shared/src/commonMain/kotlin/io/madrona/njord/model/Style.kt
+++ b/shared/src/commonMain/kotlin/io/madrona/njord/model/Style.kt
@@ -228,6 +228,8 @@ data class Source(
 
     @SerialName("url") val tileJsonUrl: String? = null, // "https://localhost:9000/v1/tile_json"
 
+    @SerialName("promoteId") val promoteId: String? = null,
+
     val data: Feature? = null,
 ) {
     companion object {


### PR DESCRIPTION
This sets [promoteId](https://maplibre.org/maplibre-style-spec/sources/#promoteid) to instructs MapLibre to use the unique `LNAM` property as the feature id. This allows consumers of the style to manipulate features by id, and enables expressions based on [feature state](https://maplibre.org/maplibre-style-spec/expressions/#feature-state).

I didn't see any tests for style generation, but let me know if you want me to add one.